### PR TITLE
Defer querying database for domain seq until it's required

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,3 @@ addons:
   - postgresql: "9.4"
 before_script:
   - cp config/travis.exs config/test.exs
-  - mix do ecto.create, ecto.migrate
-env:
-  global:
-    - MIX_ENV=test

--- a/lib/elide/elink_seq_server.ex
+++ b/lib/elide/elink_seq_server.ex
@@ -20,7 +20,7 @@ defmodule Elide.ElinkSeqServer do
   def nextval(domain_id) when is_integer(domain_id) do
     Agent.get_and_update(__MODULE__, fn(state) ->
       seq = case Map.get(state, domain_id) do
-        nil -> fetch_next_seq(domain_id)
+        nil -> get_sequence(domain_id)
         seq -> seq
       end
       state = Map.put state, domain_id, seq + 1
@@ -48,18 +48,10 @@ defmodule Elide.ElinkSeqServer do
     nextval(domain.id)
   end
 
-  defp fetch_next_seq(domain_id) do
-    domain_id
-    |> get_sequence
-  end
-
   @doc false
   def get_sequence(domain_id) when is_integer(domain_id)  do
     last_seq_query = from e in Elink, select: max(e.elink_seq),  where: e.domain_id == ^domain_id
-    seq =
-      last_seq_query
-      |> Repo.one
-    seq || 0
+    seq = Repo.one(last_seq_query) || 0
   end
 
   @doc """
@@ -68,5 +60,4 @@ defmodule Elide.ElinkSeqServer do
   def get_sequence(domain) do
     get_sequence(domain.id)
   end
-
 end

--- a/lib/elide/elink_seq_server.ex
+++ b/lib/elide/elink_seq_server.ex
@@ -19,7 +19,10 @@ defmodule Elide.ElinkSeqServer do
 
   def nextval(domain_id) when is_integer(domain_id) do
     Agent.get_and_update(__MODULE__, fn(state) ->
-      seq = Map.get state, domain_id, fetch_next_seq(domain_id)
+      seq = case Map.get(state, domain_id) do
+        nil -> fetch_next_seq(domain_id)
+        seq -> seq
+      end
       state = Map.put state, domain_id, seq + 1
       {seq + 1, state}
     end)

--- a/lib/elide/elink_seq_server.ex
+++ b/lib/elide/elink_seq_server.ex
@@ -12,26 +12,22 @@ defmodule Elide.ElinkSeqServer do
   import Ecto.Query, only: [from: 1, from: 2]
   alias Elide.{Repo, Elink, Domain}
 
-  @doc """
-  Initialize ElinkSeqServer state
-  """
-  def init do
-    Repo.all(Domain)
-    |> Enum.map(fn(d) -> {d.id, get_sequence(d)} end)
-    |> Enum.into(%{})
-  end
-
   @doc false
   def start_link() do
-    Agent.start_link(fn -> init end, name: __MODULE__)
+    Agent.start_link(fn -> Map.new end, name: __MODULE__)
   end
 
   def nextval(domain_id) when is_integer(domain_id) do
     Agent.get_and_update(__MODULE__, fn(state) ->
-      seq = Map.get state, domain_id, 0
+      seq = Map.get state, domain_id, fetch_next_seq(domain_id)
       state = Map.put state, domain_id, seq + 1
       {seq + 1, state}
     end)
+  end
+
+  def fetch_next_seq(domain_id) do
+    domain_id
+    |> get_sequence
   end
 
   @doc """
@@ -54,15 +50,20 @@ defmodule Elide.ElinkSeqServer do
     nextval(domain.id)
   end
 
-  @doc """
-  Gets the last used sequence for given domain
-  """
-  def get_sequence(domain) do
-    domain_id = domain.id
+  @doc false
+  def get_sequence(domain_id) when is_integer(domain_id)  do
     last_seq_query = from e in Elink, select: max(e.elink_seq),  where: e.domain_id == ^domain_id
     seq =
       last_seq_query
       |> Repo.one
-    seq || 1
+    seq || 0
   end
+
+  @doc """
+  Gets the last used sequence for given domain
+  """
+  def get_sequence(domain) do
+    get_sequence(domain.id)
+  end
+
 end

--- a/lib/elide/elink_seq_server.ex
+++ b/lib/elide/elink_seq_server.ex
@@ -10,7 +10,7 @@ defmodule Elide.ElinkSeqServer do
   """
 
   import Ecto.Query, only: [from: 1, from: 2]
-  alias Elide.{Repo, Elink, Domain}
+  alias Elide.{Repo, Elink}
 
   @doc false
   def start_link() do
@@ -23,11 +23,6 @@ defmodule Elide.ElinkSeqServer do
       state = Map.put state, domain_id, seq + 1
       {seq + 1, state}
     end)
-  end
-
-  def fetch_next_seq(domain_id) do
-    domain_id
-    |> get_sequence
   end
 
   @doc """
@@ -48,6 +43,11 @@ defmodule Elide.ElinkSeqServer do
   """
   def nextval(domain) do
     nextval(domain.id)
+  end
+
+  defp fetch_next_seq(domain_id) do
+    domain_id
+    |> get_sequence
   end
 
   @doc false

--- a/test/libs/elink_seq_server_test.exs
+++ b/test/libs/elink_seq_server_test.exs
@@ -18,10 +18,6 @@ defmodule Elide.ElinkSeqServerTest do
 
   test "find elink sequence for first elink for given domain" do
     domain = insert_domain()
-    assert ElinkSeqServer.get_sequence(domain) == 1
-  end
-
-  test "fetch elink sequence for all domains" do
-    assert ElinkSeqServer.init |> is_map
+    assert ElinkSeqServer.get_sequence(domain) == 0
   end
 end


### PR DESCRIPTION
Having a long running task or something that is known to fail during
start_link is not a good practice. By this change we defer querying db
to when it's required.
